### PR TITLE
Change the column target type to "response" instead of "resultText"

### DIFF
--- a/docsassist/schema.py
+++ b/docsassist/schema.py
@@ -40,7 +40,7 @@ class ApplicationType(str, Enum):
 
 
 PROMPT_COLUMN_NAME: str = "promptText"
-TARGET_COLUMN_NAME: str = "resultText"
+TARGET_COLUMN_NAME: str = "response"
 
 
 class RAGInput(BaseModel):


### PR DESCRIPTION
# Summary
Change the target_column name to response instead of resultText to match the deployment